### PR TITLE
Update query editor to use new form components

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "sign": "grafana-toolkit plugin:sign",
     "watch": "grafana-toolkit plugin:dev --watch"
   },
-	"files": ["Development.md"],
+  "files": ["Development.md"],
   "author": "Fᴀʙɪᴇɴ Wᴇʀɴʟɪ",
   "license": "Apache-2.0",
   "devDependencies": {
@@ -23,5 +23,8 @@
   },
   "engines": {
     "node": ">=12 <15"
+  },
+  "resolutions": {
+    "rxjs": "6.6.3"
   }
 }

--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -37,6 +37,7 @@ export class DataSource extends DataSourceApi<MyQuery, MyDataSourceOptions> {
     // Track pool of websockets
     this.wsList = {};
   }
+
   query(options: DataQueryRequest<MyQuery>): Observable<DataQueryResponse> {
     const streams = options.targets.map(target => {
       const query = defaults(target, defaultQuery);

--- a/src/QueryEditor.tsx
+++ b/src/QueryEditor.tsx
@@ -2,12 +2,14 @@
 import defaults from 'lodash/defaults';
 
 import React, { ChangeEvent, PureComponent } from 'react';
-import { LegacyForms } from '@grafana/ui';
+import { InlineFieldRow, InlineField, Input } from '@grafana/ui';
 import { QueryEditorProps } from '@grafana/data';
 import { DataSource } from './DataSource';
 import { defaultQuery, MyDataSourceOptions, MyQuery } from './types';
 
-const { FormField } = LegacyForms;
+// This is a temporary work-around for a styling issue related to the new Input component.
+// For more information, refer to https://github.com/grafana/grafana/issues/26512.
+import {} from '@emotion/core';
 
 type Props = QueryEditorProps<DataSource, MyQuery, MyDataSourceOptions>;
 
@@ -49,67 +51,71 @@ export class QueryEditor extends PureComponent<Props> {
     const { queryText, maxPoints, maxSeries, maxFreq, groupBy, stringFields, numberFields } = query;
 
     return (
-      <div className="gf-form-max-width-25">
-        <FormField
-          labelWidth={10}
-          value={queryText || ''}
-          onChange={this.onQueryTextChange}
-          label="Query Text"
-          tooltip="Riemann query. See test suite for examples https://github.com/riemann/riemann/blob/master/test/riemann/query_test.clj"
-          inputWidth={100}
-        />
-        <FormField
-          labelWidth={10}
-          value={groupBy || 'host,service'}
-          onChange={this.onGroupByChange}
-          label="GroupBy"
-          tooltip="Coma separated list of attributes to group series. Events sharing these attributes will end up in the same series. Defaults to 'host,service'"
-          inputWidth={16}
-        />
-        <FormField
-          labelWidth={10}
-          value={numberFields || 'metric'}
-          onChange={this.onNumberFieldsChange}
-          label="NumericFields"
-          tooltip="Coma separated list of numeric fields. Currently Riemann only provides ttl and metric as numerical data. Example: 'metric,ttl'"
-          inputWidth={16}
-        />
-        <FormField
-          labelWidth={10}
-          value={stringFields || 'state'}
-          onChange={this.onStringFieldsChange}
-          label="StringFields"
-          tooltip="Coma separated list of attributes to return as fields. Defaults to 'state'"
-          inputWidth={16}
-        />
-        <FormField
-          labelWidth={10}
-          width={4}
-          value={maxSeries}
-          onChange={this.onMaxSeriesChange}
-          label="MaxSeries"
-          type="number"
-          tooltip="Maximum number of time series. Or maximal cardinality of returned data with respect to the GroupBy tuple. Series are kept in a first-in-only kept fashion."
-        />
-        <FormField
-          labelWidth={10}
-          width={10}
-          value={maxPoints}
-          onChange={this.onMaxPointsChange}
-          label="MaxDataPoints"
-          type="number"
-          tooltip="Maximum number of time series points returned per series. Data points will be kept in a round robin fifo fashion."
-        />
-        <FormField
-          labelWidth={10}
-          width={4}
-          value={maxFreq}
-          onChange={this.onMaxFreqChange}
-          label="MaxFreq"
-          type="number"
-          tooltip="Maximum frequency of incoming events per series. For instance MaxFreq=1 and MaxSeries=10 will yield at most 10 points per second."
-        />
-      </div>
+      <>
+        <InlineFieldRow>
+          <InlineField
+            labelWidth={20}
+            label="Query text"
+            tooltip="Riemann query. See test suite for examples https://github.com/riemann/riemann/blob/master/test/riemann/query_test.clj"
+          >
+            <Input value={queryText || ''} width={25} onChange={this.onQueryTextChange} />
+          </InlineField>
+        </InlineFieldRow>
+        <InlineFieldRow>
+          <InlineField
+            labelWidth={20}
+            label="Group by"
+            tooltip="Comma separated list of attributes to group series. Events sharing these attributes will end up in the same series. Defaults to 'host,service'"
+          >
+            <Input value={groupBy || 'host,service'} width={25} onChange={this.onGroupByChange} />
+          </InlineField>
+        </InlineFieldRow>
+        <InlineFieldRow>
+          <InlineField
+            labelWidth={20}
+            label="Numeric fields"
+            tooltip="Comma separated list of numeric fields. Currently Riemann only provides ttl and metric as numerical data. Example: 'metric,ttl'"
+          >
+            <Input value={numberFields || 'metric'} width={25} onChange={this.onNumberFieldsChange} />
+          </InlineField>
+        </InlineFieldRow>
+        <InlineFieldRow>
+          <InlineField
+            labelWidth={20}
+            label="String fields"
+            tooltip="Comma separated list of attributes to return as fields. Defaults to 'state'"
+          >
+            <Input value={stringFields || 'state'} width={25} onChange={this.onStringFieldsChange} />
+          </InlineField>
+        </InlineFieldRow>
+        <InlineFieldRow>
+          <InlineField
+            labelWidth={20}
+            label="Max series"
+            tooltip="Maximum number of time series. Or maximal cardinality of returned data with respect to the GroupBy tuple. Series are kept in a first-in-only kept fashion."
+          >
+            <Input value={maxSeries} width={25} onChange={this.onMaxSeriesChange} />
+          </InlineField>
+        </InlineFieldRow>
+        <InlineFieldRow>
+          <InlineField
+            labelWidth={20}
+            label="Max data points"
+            tooltip="Maximum number of time series points returned per series. Data points will be kept in a round robin fifo fashion."
+          >
+            <Input value={maxPoints} width={25} onChange={this.onMaxPointsChange} />
+          </InlineField>
+        </InlineFieldRow>
+        <InlineFieldRow>
+          <InlineField
+            labelWidth={20}
+            label="Max frequency"
+            tooltip="Maximum frequency of incoming events per series. For instance MaxFreq=1 and MaxSeries=10 will yield at most 10 points per second."
+          >
+            <Input value={maxFreq} width={25} onChange={this.onMaxFreqChange} />
+          </InlineField>
+        </InlineFieldRow>
+      </>
     );
   }
 }


### PR DESCRIPTION
This PR replaces the legacy form components with the new [inline field](https://developers.grafana.com/ui/latest/index.html?path=/story/forms-inlinefield--basic) components.

The resolutions property in the package.json fixes a dependency issue that will hopefully arrive in an upcoming patch release. For more information, refer to [this pull request](https://github.com/grafana/grafana/pull/28657).

<img width="385" alt="Screen Shot 2020-11-20 at 15 20 54" src="https://user-images.githubusercontent.com/8396880/99810446-02391d00-2b44-11eb-945e-1bc211abc141.png">

I took the liberty to update some of the label text. Unless they're referring to an exact string of a Riemann configuration property, I think this looks friendlier to read. 

Feel free to pick and choose any of the changes. If you want to keep the old form field components, you can wrap them in a gf-form div to add padding between them.

```
<div className="gf-form">
  <FormField ... />
</div>